### PR TITLE
forbedre openapi-dokumentasjon enhetsregisteret

### DIFF
--- a/specs/enhetsregisteret.json
+++ b/specs/enhetsregisteret.json
@@ -376,7 +376,7 @@
         {
           "name": "organisasjonsnummer",
           "in": "query",
-          "description": "Organisasjonsnummeret til enheten",
+          "description": "Organisasjonsnummeret til underenhetene. Kommaseparert liste med organisasjonsnummer",
           "required": false,
           "schema": {
             "type": "string"

--- a/specs/enhetsregisteret.json
+++ b/specs/enhetsregisteret.json
@@ -172,7 +172,7 @@
         {
           "name": "organisasjonsnummer",
           "in": "query",
-          "description": "Organisasjonsnummeret til enheten",
+          "description": "Organisasjonsnummeret til enhetene. Kommaseparert liste med organisasjonsnummer",
           "required": false,
           "schema": {
             "type": "string"

--- a/specs/enhetsregisteret.json
+++ b/specs/enhetsregisteret.json
@@ -26,7 +26,14 @@
         "description": "Hent alle tjenester",
         "responses": {
           "200": {
-            "description": "Tjenester mot åpne data fra Enhetsregisteret"
+            "description": "Tjenester mot åpne data fra Enhetsregisteret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "default": {
             "description": "Udefinert feil"
@@ -161,6 +168,132 @@
           "schema": {
             "type": "integer"
           }
+        },
+        {
+          "name": "organisasjonsnummer",
+          "in": "query",
+          "description": "Organisasjonsnummeret til enheten",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "registrertIForetaksregisteret",
+          "in": "query",
+          "description": "Hvorvidt enheten er registrert i Foretaksregisteret",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "registrertIStiftelsesregisteret",
+          "in": "query",
+          "description": "Hvorvidt enheten er registrert i Stiftelsesregisteret",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "registrertIFrivillighetsregisteret",
+          "in": "query",
+          "description": "Hvorvidt enheten er registrert i Frivillighetsregisteret",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "frivilligRegistrertIMvaregisteret",
+          "in": "query",
+          "description": "Frivillig registrert i Merverdiavgiftsregisteret. Kommaseparert liste med beskrivelser.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "underTvangsavviklingEllerTvangsopplosning",
+          "in": "query",
+          "description": "Hvorvidt enheten er registrert som underTvangsavvikling eller tvangsopplosning",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "underAvvikling",
+          "in": "query",
+          "description": "Hvorvidt enheten er registrert som underAvvikling",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "fraStiftelsesdato",
+          "in": "query",
+          "description": "Tidligste stiftelsesdato for enheten",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "tilStiftelsesdato",
+          "in": "query",
+          "description": "Seneste stiftelsesdato hos enheten",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "hjemmeside",
+          "in": "query",
+          "description": "Enhetens hjemmeside",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "institusjonellSektorkode",
+          "in": "query",
+          "description": "Enhetens institusjonelle sektorkode. Kommaseparert liste med sektorkoder på 4 siffer.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "postadresse",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/Adresse"
+          }
+        },
+        {
+          "name": "forretningsadresse",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/Adresse"
+          }
+        },
+        {
+          "name": "sisteInnsendteAarsregnskap",
+          "in": "query",
+          "description": "Årstall for siste innsendte årsregnskap for enheten. Kommaseparert liste med årstall på 4 siffer",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
         }
       ],
       "get": {
@@ -168,7 +301,14 @@
         "description": "Hent alle enheter",
         "responses": {
           "200": {
-            "description": "Enheter fra Enhetsregisteret"
+            "description": "Enheter fra Enhetsregisteret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "400": {
             "description": "Ugyldig forespørsel"
@@ -225,25 +365,186 @@
     "/underenheter": {
       "parameters": [
         {
-          "name": "size",
-          "in": "query",
-          "description": "Antall ønskede treff i response. Default verdi er 20. Max dypde (page*size) er 10 000.",
-          "schema": {
-            "type": "integer"
-          }
-        },
-        {
-          "name": "page",
-          "in": "query",
-          "description": "Hvilken side som ønskes av resultatsettet. Default verdi er 0. Max dypde (page*size) er 10 000",
-          "schema": {
-            "type": "integer"
-          }
-        },
-        {
           "name": "navn",
           "in": "query",
           "description": "Filtrer på navn. Sammensatt søk på likhet. Resultat sorteres pr default etter score",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "organisasjonsnummer",
+          "in": "query",
+          "description": "Organisasjonsnummeret til enheten",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "overordnetEnhet",
+          "in": "query",
+          "description": "Organisasjonsnummeret til overordnet enhet",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "fraAntallAnsatte",
+          "in": "query",
+          "description": "Filtrer på fra antall ansatte",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "tilAntallAnsatte",
+          "in": "query",
+          "description": "Filtrer på til antall ansatte",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "registrertIMvaregisteret",
+          "in": "query",
+          "description": "Filtrer på om enheten er registrert i Merverdiregisteret",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "fraRegistreringsdatoEnhetsregisteret",
+          "in": "query",
+          "description": "Filtrer på fra registreringsdato i Enhetsregisteret.",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "tilRegistreringsdatoEnhetsregisteret",
+          "in": "query",
+          "description": "Filtrer på til registreringsdato i Enhetsregisteret.",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "fraOppstartsdato",
+          "in": "query",
+          "description": "Tidligste oppstartsdato for enheten",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "tilOppstartsdato",
+          "in": "query",
+          "description": "Seneste oppstartsdato for enheten",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "fraDatoEierskifte",
+          "in": "query",
+          "description": "Tidligste registreringsdato for eierskifte",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "tilDatoEierskifte",
+          "in": "query",
+          "description": "Seneste registreringsdato for eierskifte",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "fraNedleggelsesdato",
+          "in": "query",
+          "description": "Tidligste nedleggelsesdato for enheten",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "tilNedleggelsesdato",
+          "in": "query",
+          "description": "Seneste nedleggelsesdato for enheten",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date (ISO-8601)"
+          }
+        },
+        {
+          "name": "organisasjonsform",
+          "in": "query",
+          "description": "Filtrer på organisasjonsformkode. Kommaseparert liste.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "hjemmeside",
+          "in": "query",
+          "description": "Enhetens hjemmeside",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "postadresse",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/Adresse"
+          }
+        },
+        {
+          "name": "kommunenummer",
+          "in": "query",
+          "description": "Filtrer på kommunenummer 4 siffer.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "beliggenhetsadresse",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/Adresse"
+          }
+        },
+        {
+          "name": "naeringskode",
+          "in": "query",
+          "description": "Filtrer på næringskode. Valgfritt nivå. Kommaseparert liste.",
           "required": false,
           "schema": {
             "type": "string"
@@ -259,39 +560,19 @@
           }
         },
         {
-          "name": "organisasjonsform",
+          "name": "size",
           "in": "query",
-          "description": "Filtrer på organisasjonsformkode. Kommaseparert liste.",
-          "required": false,
+          "description": "Antall ønskede treff i response. Default verdi er 20. Max dypde (page*size) er 10 000.",
           "schema": {
-            "type": "string"
+            "type": "integer"
           }
         },
         {
-          "name": "naeringskode",
+          "name": "page",
           "in": "query",
-          "description": "Filtrer på næringskode. Valgfritt nivå. Kommaseparert liste.",
-          "required": false,
+          "description": "Hvilken side som ønskes av resultatsettet. Default verdi er 0. Max dypde (page*size) er 10 000",
           "schema": {
-            "type": "string"
-          }
-        },
-        {
-          "name": "kommunenummer",
-          "in": "query",
-          "description": "Filtrer på kommunenummer 4 siffer.",
-          "required": false,
-          "schema": {
-            "type": "string"
-          }
-        },
-        {
-          "name": "overordnetEnhet",
-          "in": "query",
-          "description": "Organisasjonsnummeret til overordnet enhet",
-          "required": false,
-          "schema": {
-            "type": "string"
+            "type": "integer"
           }
         }
       ],
@@ -300,7 +581,14 @@
         "description": "Hent alle underenheter",
         "responses": {
           "200": {
-            "description": "Underenheter fra Enhetsregisteret"
+            "description": "Underenheter fra Enhetsregisteret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "default": {
             "description": "Udefinert feil"
@@ -325,7 +613,14 @@
         "description": "Hent detaljer om underenhet",
         "responses": {
           "200": {
-            "description": "Underenhet fra Enhetsregisteret"
+            "description": "Underenhet fra Enhetsregisteret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "404": {
             "description": "Underenhet finnes ikke"
@@ -340,12 +635,48 @@
       }
     },
     "/oppdateringer/enheter": {
+      "parameters": [
+        {
+          "name": "dato",
+          "in": "query",
+          "description": "Tidligste tidsstempel for når enheten ble oppdatert. På format Datetime (ISO-8601): yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "oppdateringsid",
+          "in": "query",
+          "description": "Minste oppdateringsid for enhet. Større eller lik 1.",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "organisasjonsnummer",
+          "in": "query",
+          "description": "Organisasjonsnummeret til enheten. Kommaseparert liste med organisasjonsnummer.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "listOppdateringerEnhet",
         "description": "Hent oppdateringer på enheter",
         "responses": {
           "200": {
-            "description": "Oppdateringer på enheter fra Enhetsregisteret"
+            "description": "Oppdateringer på enheter fra Enhetsregisteret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "default": {
             "description": "Udefinert feil"
@@ -354,12 +685,48 @@
       }
     },
     "/oppdateringer/underenheter": {
+      "parameters": [
+        {
+          "name": "dato",
+          "in": "query",
+          "description": "Tidligste tidsstempel for når enheten ble oppdatert. På format Datetime (ISO-8601): yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "oppdateringsid",
+          "in": "query",
+          "description": "Minste oppdateringsid for enhet. Større eller lik 1.",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "organisasjonsnummer",
+          "in": "query",
+          "description": "Organisasjonsnummeret til enheten. Kommaseparert liste med organisasjonsnummer.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "get": {
         "operationId": "listOppdateringerUnderenhet",
         "description": "Hent oppdateringer på underenheter",
         "responses": {
           "200": {
-            "description": "Oppdateringer på underenheter fra Enhetsregisteret"
+            "description": "Oppdateringer på underenheter fra Enhetsregisteret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "default": {
             "description": "Udefinert feil"
@@ -432,6 +799,48 @@
           },
           "404": {
             "description": "Organisasjonsformen eksisterer ikke"
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/organisasjonsformer/enheter": {
+      "get": {
+        "operationId": "listOrganisasjonsformerEnheter",
+        "description": "Hent organisasjonsformer for enheter",
+        "responses": {
+          "200": {
+            "description": "Liste over mulige organisasjonsformer for enheter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Udefinert feil"
+          }
+        }
+      }
+    },
+    "/organisasjonsformer/underenheter": {
+      "get": {
+        "operationId": "listOrganisasjonsformerUnderenheter",
+        "description": "Hent organisasjonsformer for underenheter",
+        "responses": {
+          "200": {
+            "description": "Liste over mulige organisasjonsformer for underenheter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "default": {
             "description": "Udefinert feil"

--- a/specs/enhetsregisteret.json
+++ b/specs/enhetsregisteret.json
@@ -172,7 +172,7 @@
         {
           "name": "organisasjonsnummer",
           "in": "query",
-          "description": "Organisasjonsnummeret til enhetene. Kommaseparert liste med organisasjonsnummer",
+          "description": "Organisasjonsnummeret til enhetene.  Kommaseparert liste med organisasjonsnummer.",
           "required": false,
           "schema": {
             "type": "string"
@@ -271,19 +271,84 @@
           }
         },
         {
-          "name": "postadresse",
+          "name": "postadresse.kommunenummer",
           "in": "query",
+          "description": "Kommunenummer til enhetens postadresse. Kommaseparert liste med kommunenummer på 4 siffer.",
           "required": false,
           "schema": {
-            "$ref": "#/components/schemas/Adresse"
+            "type": "string"
           }
         },
         {
-          "name": "forretningsadresse",
+          "name": "postadresse.postnummer",
           "in": "query",
+          "description": "Postnummeret til enhetens postadresse. Kommaseparert liste med postnummer på 4 siffer.",
           "required": false,
           "schema": {
-            "$ref": "#/components/schemas/Adresse"
+            "type": "string"
+          }
+        },
+        {
+          "name": "postadresse.poststed",
+          "in": "query",
+          "description": "Poststedet til enhetens postadresse. Fritekst.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "postadresse.landkode",
+          "in": "query",
+          "description": "Landkode til enhetens postadresse. Kommaseparert liste med landkoder.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "postadresse.adresse",
+          "in": "query",
+          "description": "Adresse til enhetens postadresse. Kommaseparert liste med adresser.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "forretningsadresse.postnummer",
+          "in": "query",
+          "description": "Postnummer til enhetens forretningsadresse. Kommaseparert liste med postnummer på 4 siffer.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "forretningsadresse.poststed",
+          "in": "query",
+          "description": "Poststedet til enhetens forretningsadresse. Fritekst.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "forretningsadresse.landkode",
+          "in": "query",
+          "description": "Landkode til enhetens forretningsadresse. Kommaseparert liste med landkoder.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "forretningsadresse.adresse",
+          "in": "query",
+          "description": "Adresse til enhetens forretningsadresse. Kommaseparert liste med adresser.",
+          "required": false,
+          "schema": {
+            "type": "string"
           }
         },
         {
@@ -376,7 +441,7 @@
         {
           "name": "organisasjonsnummer",
           "in": "query",
-          "description": "Organisasjonsnummeret til underenhetene. Kommaseparert liste med organisasjonsnummer",
+          "description": "Organisasjonsnummeret til underenhetene.  Kommaseparert liste med organisasjonsnummer.",
           "required": false,
           "schema": {
             "type": "string"
@@ -517,11 +582,48 @@
           }
         },
         {
-          "name": "postadresse",
+          "name": "postadresse.kommunenummer",
           "in": "query",
+          "description": "Kommunenummer til enhetens postadresse. Kommaseparert liste med kommunenummer på 4 siffer.",
           "required": false,
           "schema": {
-            "$ref": "#/components/schemas/Adresse"
+            "type": "string"
+          }
+        },
+        {
+          "name": "postadresse.postnummer",
+          "in": "query",
+          "description": "Postnummeret til enhetens postadresse. Kommaseparert liste med postnummer på 4 siffer.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "postadresse.poststed",
+          "in": "query",
+          "description": "Poststedet til enhetens postadresse. Fritekst.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "postadresse.landkode",
+          "in": "query",
+          "description": "Landkode til enhetens postadresse. Kommaseparert liste med landkoder.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "postadresse.adresse",
+          "in": "query",
+          "description": "Adresse til enhetens postadresse. Kommaseparert liste med adresser.",
+          "required": false,
+          "schema": {
+            "type": "string"
           }
         },
         {
@@ -534,11 +636,39 @@
           }
         },
         {
-          "name": "beliggenhetsadresse",
+          "name": "beliggenhetsadresse.postnummer",
           "in": "query",
+          "description": "Postnummeret til enhetens beliggenhetsadresse. Kommaseparert liste med postnummer på 4 siffer.",
           "required": false,
           "schema": {
-            "$ref": "#/components/schemas/Adresse"
+            "type": "string"
+          }
+        },
+        {
+          "name": "beliggenhetsadresse.poststed",
+          "in": "query",
+          "description": "Poststedet til enhetens beliggenhetsadresse. Fritekst.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "beliggenhetsadresse.landkode",
+          "in": "query",
+          "description": "Landkode til enhetens beliggenhetsadresse. Kommaseparert liste med landkoder.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "beliggenhetsadresse.adresse",
+          "in": "query",
+          "description": "Adresse til enhetens beliggenhetsadresse. Kommaseparert liste med adresser.",
+          "required": false,
+          "schema": {
+            "type": "string"
           }
         },
         {
@@ -862,9 +992,6 @@
           "organisasjonsform": {
             "$ref": "#/components/schemas/Organisasjonsform"
           },
-          "postadresse": {
-            "$ref": "#/components/schemas/Adresse"
-          },
           "registreringsdatoEnhetsregisteret": {
             "type": "string"
           },
@@ -882,9 +1009,6 @@
           },
           "antallAnsatte": {
             "type": "integer"
-          },
-          "forretningsadresse": {
-            "$ref": "#/components/schemas/Adresse"
           },
           "stiftelsedato": {
             "type": "string"
@@ -918,34 +1042,6 @@
           },
           "_links": {
             "$ref": "#/components/schemas/Self"
-          }
-        }
-      },
-      "Adresse": {
-        "properties": {
-          "land": {
-            "type": "string"
-          },
-          "landkode": {
-            "type": "string"
-          },
-          "postnummer": {
-            "type": "string"
-          },
-          "poststed": {
-            "type": "string"
-          },
-          "adresse": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "kommune": {
-            "type": "string"
-          },
-          "kommunenummer": {
-            "type": "string"
           }
         }
       },

--- a/specs/enhetsregisteret.yml
+++ b/specs/enhetsregisteret.yml
@@ -747,8 +747,6 @@ components:
           type: string
         organisasjonsform:
           $ref: '#/components/schemas/Organisasjonsform'
-        postadresse:
-          $ref: '#/components/schemas/Adresse'
         registreringsdatoEnhetsregisteret:
           type: string
         registrertIMvaregisteret:
@@ -761,8 +759,6 @@ components:
           $ref: '#/components/schemas/Naeringskode'
         antallAnsatte:
           type: integer
-        forretningsadresse:
-          $ref: '#/components/schemas/Adresse'
         stiftelsedato:
           type: string
         institusjonellSektorkode:
@@ -785,24 +781,6 @@ components:
           type: string
         _links:
           $ref: '#/components/schemas/Self'
-    Adresse:
-      properties:
-        land:
-          type: string
-        landkode:
-          type: string
-        postnummer:
-          type: string
-        poststed:
-          type: string
-        adresse:
-          type: array
-          items:
-            type: string
-        kommune:
-          type: string
-        kommunenummer:
-          type: string
     Naeringskode:
       properties:
         kode:

--- a/specs/enhetsregisteret.yml
+++ b/specs/enhetsregisteret.yml
@@ -344,7 +344,7 @@ paths:
           type: string
       - name: organisasjonsnummer
         in: query
-        description: Organisasjonsnummeret til enheten
+        description: Organisasjonsnummeret til underenhetene.  Kommaseparert liste med organisasjonsnummer.
         required: false
         schema:
           type: string
@@ -753,4 +753,3 @@ components:
       properties:
         href:
           type: string
-

--- a/specs/enhetsregisteret.yml
+++ b/specs/enhetsregisteret.yml
@@ -117,6 +117,10 @@ paths:
       responses:
         '200':
           description: Tjenester mot åpne data fra Enhetsregisteret
+          content:
+            application/json:
+              schema:
+                type: string
         default:
           description: Udefinert feil
   /enheter:
@@ -205,12 +209,100 @@ paths:
         required: false
         schema:
           type: integer
+      - name: organisasjonsnummer
+        in: query
+        description: Organisasjonsnummeret til enheten
+        required: false
+        schema:
+          type: string
+      - name: registrertIForetaksregisteret
+        in: query
+        description: Hvorvidt enheten er registrert i Foretaksregisteret
+        required: false
+        schema:
+          type: boolean
+      - name: registrertIStiftelsesregisteret
+        in: query
+        description: Hvorvidt enheten er registrert i Stiftelsesregisteret
+        required: false
+        schema:
+          type: boolean
+      - name: registrertIFrivillighetsregisteret
+        in: query
+        description: Hvorvidt enheten er registrert i Frivillighetsregisteret
+        required: false
+        schema:
+          type: boolean
+      - name: frivilligRegistrertIMvaregisteret
+        in: query
+        description: Frivillig registrert i Merverdiavgiftsregisteret. Kommaseparert liste med beskrivelser.
+        required: false
+        schema:
+          type: string
+      - name: underTvangsavviklingEllerTvangsopplosning
+        in: query
+        description: Hvorvidt enheten er registrert som underTvangsavvikling eller tvangsopplosning
+        required: false
+        schema:
+          type: boolean
+      - name: underAvvikling
+        in: query
+        description: Hvorvidt enheten er registrert som underAvvikling
+        required: false
+        schema:
+          type: boolean
+      - name: fraStiftelsesdato
+        in: query
+        description: Tidligste stiftelsesdato for enheten
+        required: false
+        schema:
+          type: string
+          format: date (ISO-8601)
+      - name: tilStiftelsesdato
+        in: query
+        description: Seneste stiftelsesdato hos enheten
+        required: false
+        schema:
+          type: string
+          format: date (ISO-8601)
+      - name: hjemmeside
+        in: query
+        description: Enhetens hjemmeside
+        required: false
+        schema:
+          type: string
+      - name: institusjonellSektorkode
+        in: query
+        description: Enhetens institusjonelle sektorkode. Kommaseparert liste med sektorkoder på 4 siffer.
+        required: false
+        schema:
+          type: string
+      - name: postadresse
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/Adresse'
+      - name: forretningsadresse
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/Adresse'
+      - name: sisteInnsendteAarsregnskap
+        in: query
+        description: Årstall for siste innsendte årsregnskap for enheten. Kommaseparert liste med årstall på 4 siffer
+        required: false
+        schema:
+          type: string
     get:
       operationId: listEnheter
       description: Hent alle enheter
       responses:
         '200':
           description: Enheter fra Enhetsregisteret
+          content:
+            application/json:
+              schema:
+                type: string
         '400':
           description: Ugyldig forespørsel
         default:
@@ -244,6 +336,138 @@ paths:
           description: Udefinert feil
   /underenheter:
     parameters:
+      - name: navn
+        in: query
+        description: Filtrer på navn. Sammensatt søk på likhet. Resultat sorteres pr default etter score
+        required: false
+        schema:
+          type: string
+      - name: organisasjonsnummer
+        in: query
+        description: Organisasjonsnummeret til enheten
+        required: false
+        schema:
+          type: string
+      - name: overordnetEnhet
+        in: query
+        description: Organisasjonsnummeret til overordnet enhet
+        required: false
+        schema:
+          type: string
+      - name: fraAntallAnsatte
+        in: query
+        description: Filtrer på fra antall ansatte
+        required: false
+        schema:
+          type: integer
+      - name: tilAntallAnsatte
+        in: query
+        description: Filtrer på til antall ansatte
+        required: false
+        schema:
+          type: integer
+      - name: registrertIMvaregisteret
+        in: query
+        description: Filtrer på om enheten er registrert i Merverdiregisteret
+        required: false
+        schema:
+          type: boolean
+      - name: fraRegistreringsdatoEnhetsregisteret
+        in: query
+        description: Filtrer på fra registreringsdato i Enhetsregisteret.
+        required: false
+        schema:
+          type: string
+          format: date (ISO-8601)
+      - name: tilRegistreringsdatoEnhetsregisteret
+        in: query
+        description: Filtrer på til registreringsdato i Enhetsregisteret.
+        required: false
+        schema:
+          type: string
+          format: date (ISO-8601)
+      - name: fraOppstartsdato
+        in: query
+        description: Tidligste oppstartsdato for enheten
+        required: false
+        schema:
+          type: string
+          format: date (ISO-8601)
+      - name: tilOppstartsdato
+        in: query
+        description: Seneste oppstartsdato for enheten
+        required: false
+        schema:
+          type: string
+          format: date (ISO-8601)
+      - name: fraDatoEierskifte
+        in: query
+        description: Tidligste registreringsdato for eierskifte
+        required: false
+        schema:
+          type: string
+          format: date (ISO-8601)
+      - name: tilDatoEierskifte
+        in: query
+        description: Seneste registreringsdato for eierskifte
+        required: false
+        schema:
+          type: string
+          format: date (ISO-8601)
+      - name: fraNedleggelsesdato
+        in: query
+        description: Tidligste nedleggelsesdato for enheten
+        required: false
+        schema:
+          type: string
+          format: date (ISO-8601)
+      - name: tilNedleggelsesdato
+        in: query
+        description: Seneste nedleggelsesdato for enheten
+        required: false
+        schema:
+          type: string
+          format: date (ISO-8601)
+      - name: organisasjonsform
+        in: query
+        description: Filtrer på organisasjonsformkode. Kommaseparert liste.
+        required: false
+        schema:
+          type: string
+      - name: hjemmeside
+        in: query
+        description: Enhetens hjemmeside
+        required: false
+        schema:
+          type: string
+      - name: postadresse
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/Adresse'
+      - name: kommunenummer
+        in: query
+        description: Filtrer på kommunenummer 4 siffer.
+        required: false
+        schema:
+          type: string
+      - name: beliggenhetsadresse
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/Adresse'
+      - name: naeringskode
+        in: query
+        description: Filtrer på næringskode. Valgfritt nivå. Kommaseparert liste.
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        description: Sorter resultatsett på feltnavn. Merk at navn må sorteres på navn.norwegian
+        required: false
+        schema:
+          type: string
       - name: size
         in: query
         description: Antall ønskede treff i response. Default verdi er 20. Max dypde (page*size) er 10 000.
@@ -254,48 +478,16 @@ paths:
         description: Hvilken side som ønskes av resultatsettet. Default verdi er 0. Max dypde (page*size) er 10 000
         schema:
           type: integer
-      - name: navn
-        in: query
-        description: Filtrer på navn. Sammensatt søk på likhet. Resultat sorteres pr default etter score
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        description: Sorter resultatsett på feltnavn. Merk at navn må sorteres på navn.norwegian
-        required: false
-        schema:
-          type: string
-      - name: organisasjonsform
-        in: query
-        description: Filtrer på organisasjonsformkode. Kommaseparert liste.
-        required: false
-        schema:
-          type: string
-      - name: naeringskode
-        in: query
-        description: Filtrer på næringskode. Valgfritt nivå. Kommaseparert liste.
-        required: false
-        schema:
-          type: string
-      - name: kommunenummer
-        in: query
-        description: Filtrer på kommunenummer 4 siffer.
-        required: false
-        schema:
-          type: string
-      - name: overordnetEnhet
-        in: query
-        description: Organisasjonsnummeret til overordnet enhet
-        required: false
-        schema:
-          type: string
     get:
       operationId: listUnderenheter
       description: Hent alle underenheter
       responses:
         '200':
           description: Underenheter fra Enhetsregisteret
+          content:
+            application/json:
+              schema:
+                type: string
         default:
           description: Udefinert feil
   /underenheter/{organisasjonsnummer}:
@@ -312,6 +504,10 @@ paths:
       responses:
         '200':
           description: Underenhet fra Enhetsregisteret
+          content:
+            application/json:
+              schema:
+                type: string
         '404':
           description: Underenhet finnes ikke
         '410':
@@ -319,21 +515,67 @@ paths:
         default:
           description: Udefinert feil
   /oppdateringer/enheter:
+    parameters:
+      - name: dato
+        in: query
+        description: "Tidligste tidsstempel for når enheten ble oppdatert. På format Datetime (ISO-8601): yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        required: false
+        schema:
+          type: string
+      - name: oppdateringsid
+        in: query
+        description: Minste oppdateringsid for enhet. Større eller lik 1.
+        required: false
+        schema:
+          type: integer
+      - name: organisasjonsnummer
+        in: query
+        description: Organisasjonsnummeret til enheten. Kommaseparert liste med organisasjonsnummer.
+        required: false
+        schema:
+          type: string
     get:
       operationId: listOppdateringerEnhet
       description: Hent oppdateringer på enheter
       responses:
         '200':
           description:  Oppdateringer på enheter fra Enhetsregisteret
+          content:
+            application/json:
+              schema:
+                type: string
         default:
           description: Udefinert feil
   /oppdateringer/underenheter:
+    parameters:
+      - name: dato
+        in: query
+        description: "Tidligste tidsstempel for når enheten ble oppdatert. På format Datetime (ISO-8601): yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        required: false
+        schema:
+          type: string
+      - name: oppdateringsid
+        in: query
+        description: Minste oppdateringsid for enhet. Større eller lik 1.
+        required: false
+        schema:
+          type: integer
+      - name: organisasjonsnummer
+        in: query
+        description: Organisasjonsnummeret til enheten. Kommaseparert liste med organisasjonsnummer.
+        required: false
+        schema:
+          type: string
     get:
       operationId: listOppdateringerUnderenhet
       description: Hent oppdateringer på underenheter
       responses:
         '200':
           description:  Oppdateringer på underenheter fra Enhetsregisteret
+          content:
+            application/json:
+              schema:
+                type: string
         default:
           description: Udefinert feil
   /organisasjonsformer:
@@ -379,6 +621,32 @@ paths:
                 $ref: '#/components/schemas/Organisasjonsform'
         '404':
           description: Organisasjonsformen eksisterer ikke
+        default:
+          description: Udefinert feil
+  /organisasjonsformer/enheter:
+    get:
+      operationId: listOrganisasjonsformerEnheter
+      description: Hent organisasjonsformer for enheter
+      responses:
+        '200':
+          description: Liste over mulige organisasjonsformer for enheter
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          description: Udefinert feil
+  /organisasjonsformer/underenheter:
+    get:
+      operationId: listOrganisasjonsformerUnderenheter
+      description: Hent organisasjonsformer for underenheter
+      responses:
+        '200':
+          description: Liste over mulige organisasjonsformer for underenheter
+          content:
+            application/json:
+              schema:
+                type: string
         default:
           description: Udefinert feil
 components:
@@ -485,3 +753,4 @@ components:
       properties:
         href:
           type: string
+

--- a/specs/enhetsregisteret.yml
+++ b/specs/enhetsregisteret.yml
@@ -277,16 +277,60 @@ paths:
         required: false
         schema:
           type: string
-      - name: postadresse
+      - name: postadresse.kommunenummer
         in: query
+        description: Kommunenummer til enhetens postadresse. Kommaseparert liste med kommunenummer på 4 siffer.
         required: false
         schema:
-          $ref: '#/components/schemas/Adresse'
-      - name: forretningsadresse
+          type: string
+      - name: postadresse.postnummer
         in: query
+        description: Postnummeret til enhetens postadresse. Kommaseparert liste med postnummer på 4 siffer.
         required: false
         schema:
-          $ref: '#/components/schemas/Adresse'
+          type: string
+      - name: postadresse.poststed
+        in: query
+        description: Poststedet til enhetens postadresse. Fritekst.
+        required: false
+        schema:
+          type: string
+      - name: postadresse.landkode
+        in: query
+        description: Landkode til enhetens postadresse. Kommaseparert liste med landkoder.
+        required: false
+        schema:
+          type: string
+      - name: postadresse.adresse
+        in: query
+        description: Adresse til enhetens postadresse. Kommaseparert liste med adresser.
+        required: false
+        schema:
+          type: string
+      - name: forretningsadresse.postnummer
+        in: query
+        description: Postnummer til enhetens forretningsadresse. Kommaseparert liste med postnummer på 4 siffer.
+        required: false
+        schema:
+          type: string
+      - name: forretningsadresse.poststed
+        in: query
+        description: Poststedet til enhetens forretningsadresse. Fritekst.
+        required: false
+        schema:
+          type: string
+      - name: forretningsadresse.landkode
+        in: query
+        description: Landkode til enhetens forretningsadresse. Kommaseparert liste med landkoder.
+        required: false
+        schema:
+          type: string
+      - name: forretningsadresse.adresse
+        in: query
+        description: Adresse til enhetens forretningsadresse. Kommaseparert liste med adresser.
+        required: false
+        schema:
+          type: string
       - name: sisteInnsendteAarsregnskap
         in: query
         description: Årstall for siste innsendte årsregnskap for enheten. Kommaseparert liste med årstall på 4 siffer
@@ -440,22 +484,66 @@ paths:
         required: false
         schema:
           type: string
-      - name: postadresse
+      - name: postadresse.kommunenummer
         in: query
+        description: Kommunenummer til enhetens postadresse. Kommaseparert liste med kommunenummer på 4 siffer.
         required: false
         schema:
-          $ref: '#/components/schemas/Adresse'
+          type: string
+      - name: postadresse.postnummer
+        in: query
+        description: Postnummeret til enhetens postadresse. Kommaseparert liste med postnummer på 4 siffer.
+        required: false
+        schema:
+          type: string
+      - name: postadresse.poststed
+        in: query
+        description: Poststedet til enhetens postadresse. Fritekst.
+        required: false
+        schema:
+          type: string
+      - name: postadresse.landkode
+        in: query
+        description: Landkode til enhetens postadresse. Kommaseparert liste med landkoder.
+        required: false
+        schema:
+          type: string
+      - name: postadresse.adresse
+        in: query
+        description: Adresse til enhetens postadresse. Kommaseparert liste med adresser.
+        required: false
+        schema:
+          type: string
       - name: kommunenummer
         in: query
         description: Filtrer på kommunenummer 4 siffer.
         required: false
         schema:
           type: string
-      - name: beliggenhetsadresse
+      - name: beliggenhetsadresse.postnummer
         in: query
+        description: Postnummeret til enhetens beliggenhetsadresse. Kommaseparert liste med postnummer på 4 siffer.
         required: false
         schema:
-          $ref: '#/components/schemas/Adresse'
+          type: string
+      - name: beliggenhetsadresse.poststed
+        in: query
+        description: Poststedet til enhetens beliggenhetsadresse. Fritekst.
+        required: false
+        schema:
+          type: string
+      - name: beliggenhetsadresse.landkode
+        in: query
+        description: Landkode til enhetens beliggenhetsadresse. Kommaseparert liste med landkoder.
+        required: false
+        schema:
+          type: string
+      - name: beliggenhetsadresse.adresse
+        in: query
+        description: Adresse til enhetens beliggenhetsadresse. Kommaseparert liste med adresser.
+        required: false
+        schema:
+          type: string
       - name: naeringskode
         in: query
         description: Filtrer på næringskode. Valgfritt nivå. Kommaseparert liste.

--- a/specs/enhetsregisteret.yml
+++ b/specs/enhetsregisteret.yml
@@ -211,7 +211,7 @@ paths:
           type: integer
       - name: organisasjonsnummer
         in: query
-        description: Organisasjonsnummeret til enheten
+        description: Organisasjonsnummeret til enhetene.  Kommaseparert liste med organisasjonsnummer.
         required: false
         schema:
           type: string


### PR DESCRIPTION
* legge til noen flere endepunkter i dokumentasjonen
* legge til en enkel responstype (application/json) for endepunkter som
manglet responstype helt (Void)
* legge til flere query-parametre i henhold til spesifikasjon https://data.brreg.no/enhetsregisteret/api/docs/index.html